### PR TITLE
Add manufacturer shyugh with lowercase for Dimmer-Switch-ZB3.0

### DIFF
--- a/drivers/eco-dim07-zigbee/driver.compose.json
+++ b/drivers/eco-dim07-zigbee/driver.compose.json
@@ -29,7 +29,7 @@
     "small": "{{driverAssetsPath}}/images/small.png"
   },
   "zigbee": {
-    "manufacturerName": ["EcoDim BV", "EcoDim B.V", "EcoDim B.V.", "Ember", "abcd", "Shyugj"],
+    "manufacturerName": ["EcoDim BV", "EcoDim B.V", "EcoDim B.V.", "Ember", "abcd", "Shyugj", "shyugj"],
     "productId": ["Dimmer-Switch-ZB3.0"],
     "endpoints": {
       "1": {


### PR DESCRIPTION
My switch was not recognized, I added a lowercase manufacturer entry (as reported by my switch) and it's now correctly installing into my version of the app. 

Hopefully this'll make it into the official version :)